### PR TITLE
use `private: true` to avoid missing maintainer warning

### DIFF
--- a/inst/templates/widget_package.json.txt
+++ b/inst/templates/widget_package.json.txt
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     %s
   },


### PR DESCRIPTION
@alandipert 

Avoids warning produced when `yarn` is executed. This component is also setup to never be sent to npm, so it can be private.

