### PR TITLE
Scaffold multiple npm libs

### DIFF
--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -44,6 +44,8 @@ scaffoldReactWidget <- function(name, npmPkgs = NULL, edit = interactive()){
 toDepJSON <- function(npmPkgs) {
   if (is.null(npmPkgs)) {
     ""
+  } else if (!length(names(npmPkgs))) {
+    stop("Must specify npm package names in the names attributes of npmPkgs")
   } else {
     paste0(sprintf('"%s": "%s"', names(npmPkgs), npmPkgs), collapse = ",\n")
   }

--- a/R/scaffold.R
+++ b/R/scaffold.R
@@ -4,11 +4,10 @@
 #' R package.
 #'
 #' @param name Name of widget
-#' @param npmPkg Optional \href{https://npmjs.com/}{NPM} package upon which this
-#'   widget is based, a named list with two elements: \code{name} and
-#'   \href{https://docs.npmjs.com/files/package.json#dependencies}{version}. If
-#'   you specify this parameter the package will be added to the
-#'   \code{dependency} section of the generated \code{package.json}.
+#' @param npmPkgs Optional \href{https://npmjs.com/}{NPM} packages upon which
+#'   this widget is based which will be used to populate \code{package.json}.
+#'   Should be a named list of names to
+#'   \href{https://docs.npmjs.com/files/package.json#dependencies}{versions}.
 #' @param edit Automatically open the widget's JavaScript source file after
 #'   creating the scaffolding.
 #'
@@ -16,7 +15,7 @@
 #'   you wish to add the widget to.
 #'
 #' @export
-scaffoldReactWidget <- function(name, npmPkg = NULL, edit = interactive()){
+scaffoldReactWidget <- function(name, npmPkgs = NULL, edit = interactive()){
   if (!file.exists('DESCRIPTION')){
     stop(
       "You need to create a package to house your widget first!",
@@ -29,7 +28,7 @@ scaffoldReactWidget <- function(name, npmPkg = NULL, edit = interactive()){
   package <- read.dcf('DESCRIPTION')[[1,"Package"]]
   addWidgetConstructor(name, package, edit)
   addWidgetYAML(name, edit)
-  addPackageJSON(toDepJSON(npmPkg))
+  addPackageJSON(toDepJSON(npmPkgs))
   addWebpackConfig(name)
   addWidgetJS(name, edit)
   addExampleApp(name)
@@ -42,11 +41,11 @@ scaffoldReactWidget <- function(name, npmPkg = NULL, edit = interactive()){
   message("To build JavaScript run: yarn run webpack --mode=development")
 }
 
-toDepJSON <- function(npmPkg) {
-  if (is.null(npmPkg)) {
+toDepJSON <- function(npmPkgs) {
+  if (is.null(npmPkgs)) {
     ""
   } else {
-    sprintf('"%s": "%s"', npmPkg$name, npmPkg$version)
+    paste0(sprintf('"%s": "%s"', names(npmPkgs), npmPkgs), collapse = ",\n")
   }
 }
 
@@ -106,8 +105,8 @@ addWidgetYAML <- function(name, edit){
   if (edit) fileEdit(file_)
 }
 
-addPackageJSON <- function(npmPkg) {
-  tpl <- renderTemplate(slurp('templates/widget_package.json.txt'), list(npmPkg = npmPkg))
+addPackageJSON <- function(npmPkgs) {
+  tpl <- renderTemplate(slurp('templates/widget_package.json.txt'), list(npmPkgs = npmPkgs))
   if (!file.exists('package.json')) {
     cat(tpl, file = 'package.json')
     message('Created package.json')

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/reactR)](https://cran.r-project.org/package=reactR)
 [![Travis-CI Build
 Status](https://travis-ci.org/react-R/reactR.svg?branch=master)](https://travis-ci.org/react-R/reactR)
+[![Slack Status](http://reactr-slackin.herokuapp.com/badge.svg)](http://reactr-slackin.herokuapp.com/badge.svg)
 
 `reactR` provides a set of convenience functions for using
 [`React`](https://facebook.github.io/react) in `R` with `htmlwidget`
@@ -92,3 +93,7 @@ We welcome contributors and would love your participation. Please note
 that this project is released with a [Contributor Code of
 Conduct](CONDUCT.md). By participating in this project you agree to
 abide by the terms.
+
+## Community
+
+We operate a [Slack](https://slack.com) workspace you are [more than welcome to join](http://reactr-slackin.herokuapp.com/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/reactR)](https://cran.r-project.org/package=reactR)
 [![Travis-CI Build
 Status](https://travis-ci.org/react-R/reactR.svg?branch=master)](https://travis-ci.org/react-R/reactR)
-[![Slack Status](http://reactr-slackin.herokuapp.com/badge.svg)](http://reactr-slackin.herokuapp.com/badge.svg)
+[![Slack Status](https://reactr-slackin.herokuapp.com/badge.svg)](https://reactr-slackin.herokuapp.com/)
 
 `reactR` provides a set of convenience functions for using
 [`React`](https://facebook.github.io/react) in `R` with `htmlwidget`

--- a/inst/templates/widget_package.json.txt
+++ b/inst/templates/widget_package.json.txt
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    ${npmPkg}
+    ${npmPkgs}
   },
   "devDependencies": {
     "webpack": "^4.27.1",

--- a/man/scaffoldReactWidget.Rd
+++ b/man/scaffoldReactWidget.Rd
@@ -4,16 +4,15 @@
 \alias{scaffoldReactWidget}
 \title{Create implementation scaffolding for a React.js-based HTML widget}
 \usage{
-scaffoldReactWidget(name, npmPkg = NULL, edit = interactive())
+scaffoldReactWidget(name, npmPkgs = NULL, edit = interactive())
 }
 \arguments{
 \item{name}{Name of widget}
 
-\item{npmPkg}{Optional \href{https://npmjs.com/}{NPM} package upon which this
-widget is based, a named list with two elements: \code{name} and
-\href{https://docs.npmjs.com/files/package.json#dependencies}{version}. If
-you specify this parameter the package will be added to the
-\code{dependency} section of the generated \code{package.json}.}
+\item{npmPkgs}{Optional \href{https://npmjs.com/}{NPM} packages upon which
+this widget is based which will be used to populate \code{package.json}.
+Should be a named list of names to
+\href{https://docs.npmjs.com/files/package.json#dependencies}{versions}.}
 
 \item{edit}{Automatically open the widget's JavaScript source file after
 creating the scaffolding.}

--- a/vignettes/intro_htmlwidgets.Rmd
+++ b/vignettes/intro_htmlwidgets.Rmd
@@ -49,7 +49,7 @@ usethis::create_package("~/sparklines")
 # Inject the widget templating
 withr::with_dir(
   "~/sparklines", 
-  reactR::scaffoldReactWidget("sparklines", list(name = "react-sparklines", version = "^1.7.0"))
+  reactR::scaffoldReactWidget("sparklines", list("react-sparklines" = "^1.7.0"))
 )
 ```
 

--- a/vignettes/intro_htmlwidgets.Rmd
+++ b/vignettes/intro_htmlwidgets.Rmd
@@ -57,7 +57,7 @@ withr::with_dir(
 
 ### Building the JavaScript
 
-The next step is to navigate to the newly-created `sparklines` directory in your terminal. Then, run the following commands:
+The next step is to navigate to the newly-created `sparklines` project and run the following R commands:
 
 ```{r}
 system("yarn install")


### PR DESCRIPTION
Makes improvements suggested by @cpsievert in #8; the `npmPkg` argument is now called `npmPkgs`, and the user may supply multiple npm dependencies as a named list mapping name to version.

#11 should be merged to master first.