### PR TITLE
set modules option of es2015 preset to false

### DIFF
--- a/R/babel.R
+++ b/R/babel.R
@@ -24,5 +24,5 @@ babel_transform <- function(code=""){
     )
   )
   ctx$assign('code', code)
-  ctx$get('Babel.transform(code,{ presets: ["es2015","react"] }).code')
+  ctx$get('Babel.transform(code,{ presets: [["es2015", {modules: false}],"react"] }).code')
 }


### PR DESCRIPTION
Thanks to @alandipert for suggesting this change. The motivation is to suppress the `"use strict"` output which makes https://github.com/ramnathv/htmlwidgets/issues/326 an easier problem to solve.

I'm sure there's an argument to be had for wanting to `"use strict"`, so perhaps we should consider adding an argument to control this in `babel_transform()`?