### PR TITLE
Treat generated JS files like binaries in git diffs, github PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/inst/www/react-tools/react-tools.js binary
+/inst/www/react-tools/react-tools.js.map binary


### PR DESCRIPTION
This adds a `.gitattributes` file which configures git to treat our generated JS files as binaries in diffs.

This will keep gobs of incomprehensible generated JS out of our PRs and diffs.