### PR TITLE
fix template to pass style and only do 1 `%`

### DIFF
--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -38,7 +38,7 @@ ${name} <- function(message, width = NULL, height = NULL, elementId = NULL) {
 #' @name ${name}-shiny
 #'
 #' @export
-${name}Output <- function(outputId, width = '100%%', height = '400px'){
+${name}Output <- function(outputId, width = '100%', height = '400px'){
   htmlwidgets::shinyWidgetOutput(outputId, '${name}', width, height, package = '${package}')
 }
 
@@ -57,6 +57,6 @@ ${name}_html <- function(id, style, class, ...) {
     reactR::html_dependency_corejs(),
     reactR::html_dependency_react(),
     reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class)
+    htmltools::tags$div(id = id, class = class, style = style)
   )
 }


### PR DESCRIPTION
fix for #20

1) `style` not passed to the tag in the `*_html` tag.
2) `%%` not necessary since not using `sprintf` to populate template.