### PR TITLE
pass NULL as null for value and configuration

### DIFF
--- a/R/reacttools.R
+++ b/R/reacttools.R
@@ -145,10 +145,10 @@ createReactShinyInput <- function(inputId,
     container(id = inputId, class = class),
     htmltools::tags$script(id = sprintf("%s_value", inputId),
                            type = "application/json",
-                           jsonlite::toJSON(value, auto_unbox = TRUE)),
+                           jsonlite::toJSON(value, auto_unbox = TRUE, null = "null")),
     htmltools::tags$script(id = sprintf("%s_configuration", inputId),
                            type = "application/json",
-                           jsonlite::toJSON(configuration, auto_unbox = TRUE)),
+                           jsonlite::toJSON(configuration, auto_unbox = TRUE, null = "null")),
     dependencies
   )
 }


### PR DESCRIPTION
@alandipert currently `NULL` for `value` or `configuration` are passed to JS as `{}`.  This pull changes that to pass `NULL` as `null`, which I think will make for the result a user would expect.  I ran into this with `rfabric` and was having to add a lot of boilerplate to deal with `()` when I wanted it to be `null`.