### PR TITLE
update eslint to 4.18.2 from 4.14.x

### DIFF
--- a/inst/www/core-js/package.json
+++ b/inst/www/core-js/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "LiveScript": "1.3.x",
     "es-observable-tests": "0.2.x",
-    "eslint": "4.14.x",
+    "eslint": "4.18.2",
     "eslint-plugin-import": "2.8.x",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
This PR fixes potential security vulnerability.

When I use `glin/reactable` in my blogdown site, GitHub warns me that there is a potential security vulnerability:

![image](https://user-images.githubusercontent.com/30277794/63488052-89828580-c4e8-11e9-853c-e2c7f426fad6.png)

Eslint fixes the issue by https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09

Thus, I suggest updating eslint to 4.18.2.
As far as I checked change log, there seems to be no breaking changes from 4.14.x.