### PR TITLE
template improvements

### DIFF
--- a/inst/templates/input_r.txt
+++ b/inst/templates/input_r.txt
@@ -2,7 +2,6 @@
 #'
 #' <Add Description>
 #'
-#' @importFrom shiny restoreInput
 #' @importFrom reactR createReactShinyInput
 #' @importFrom htmltools htmlDependency tags
 #'

--- a/inst/templates/webpack.config.js.txt
+++ b/inst/templates/webpack.config.js.txt
@@ -4,7 +4,6 @@ module.exports = {
     mode: 'development',
     entry: path.join(__dirname, 'srcjs', '${name}.jsx'),
     output: {
-        path: path.join(__dirname, 'inst', 'www', '${package}', '${name}'),
         path: path.join(__dirname, '${outputPath}'),
         filename: '${name}.js'
     },

--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -50,7 +50,7 @@ render${capName} <- function(expr, env = parent.frame(), quoted = FALSE) {
 }
 
 #' Called by HTMLWidgets to produce the widget's root element.
-#' @rdname ${name}-shiny
+#' @noRd
 ${name}_html <- function(id, style, class, ...) {
   htmltools::tagList(
     # Necessary for RStudio viewer version < 1.2


### PR DESCRIPTION
As discussed in #44 and proposed by @stla, this pull changes the template (s)

1.  `noRd` for internal widget_html function
1. removes duplicate `path` from webpack.config.js
1. removes unused `importFrom shiny restoreInput` in input template

Please test if you have a chance.