### PR TITLE
compliance with the new htmlwidgets convention

### DIFF
--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -21,6 +21,18 @@ ${name} <- function(message, width = NULL, height = NULL, elementId = NULL) {
   )
 }
 
+#' Called by HTMLWidgets to produce the widget's root element.
+#' @noRd
+widget_html.${name} <- function(id, style, class, ...) {
+  htmltools::tagList(
+    # Necessary for RStudio viewer version < 1.2
+    reactR::html_dependency_corejs(),
+    reactR::html_dependency_react(),
+    reactR::html_dependency_reacttools(),
+    htmltools::tags$div(id = id, class = class, style = style)
+  )
+}
+
 #' Shiny bindings for ${name}
 #'
 #' Output and render functions for using ${name} within Shiny
@@ -47,16 +59,4 @@ ${name}Output <- function(outputId, width = '100%', height = '400px'){
 render${capName} <- function(expr, env = parent.frame(), quoted = FALSE) {
   if (!quoted) { expr <- substitute(expr) } # force quoted
   htmlwidgets::shinyRenderWidget(expr, ${name}Output, env, quoted = TRUE)
-}
-
-#' Called by HTMLWidgets to produce the widget's root element.
-#' @rdname ${name}-shiny
-${name}_html <- function(id, style, class, ...) {
-  htmltools::tagList(
-    # Necessary for RStudio viewer version < 1.2
-    reactR::html_dependency_corejs(),
-    reactR::html_dependency_react(),
-    reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class, style = style)
-  )
 }


### PR DESCRIPTION
From [the htmlwidgets 1.5.3 NEWS](https://cran.r-project.org/web/packages/htmlwidgets/news/news.html):

> Support a new `PACKAGE::widget_html.WIDGETNAME` convention for defining custom widget HTML. This replaces the earlier `PACKAGE::WIDGETNAME_html` convention, which continues to work but may be deprecated at some point in the future. The goal for the new convention is to prevent accidentally matching functions that were never intended for this purpose. 