### PR TITLE
allow import "path/style.css" inside jsx (update webpack.config.js bo…

### DIFF
--- a/inst/templates/package.json.txt
+++ b/inst/templates/package.json.txt
@@ -9,6 +9,8 @@
     "@babel/core": "^7.2.0",
     "babel-loader": "^8.0.4",
     "@babel/preset-env": "^7.2.0",
-    "@babel/preset-react": "^7.0.0"
+    "@babel/preset-react": "^7.0.0",
+    "css-loader": "^5.0.1",
+    "style-loader": "^2.0.0"
   }
 }

--- a/inst/templates/webpack.config.js.txt
+++ b/inst/templates/webpack.config.js.txt
@@ -16,6 +16,11 @@ module.exports = {
                 options: {
                     presets: ['@babel/preset-env', '@babel/preset-react']
                 }
+            },
+            // For CSS so that import "path/style.css"; works
+            {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader']
             }
         ]
     },


### PR DESCRIPTION
This will allow:

```js
import "path-to-css/style.min.css";
```

inside any srcjs/file.jsx  without crashing `yarn run webpack`.  Maybe there was a reason not to put it. Let me know ;) 