### PR TITLE
fix: remove useless percent sign

### DIFF
--- a/inst/templates/widget_r.txt
+++ b/inst/templates/widget_r.txt
@@ -39,7 +39,7 @@ widget_html.${name} <- function(id, style, class, ...) {
 #' applications and interactive Rmd documents.
 #'
 #' @param outputId output variable to read from
-#' @param width,height Must be a valid CSS unit (like \code{'100\%%'},
+#' @param width,height Must be a valid CSS unit (like \code{'100\%'},
 #'   \code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
 #'   string and have \code{'px'} appended.
 #' @param expr An expression that generates a ${name}


### PR DESCRIPTION
The default document generated will not pass the check and show the warning below
> @param mismatched braces or quotes